### PR TITLE
Calendar UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ task coverage(type: JacocoReport) {
 dependencies {
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
+    implementation 'com.calendarfx:view:11.12.5'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'

--- a/src/main/java/seedu/address/ui/CalendarCard.java
+++ b/src/main/java/seedu/address/ui/CalendarCard.java
@@ -1,0 +1,56 @@
+package seedu.address.ui;
+import com.calendarfx.model.Calendar;
+import com.calendarfx.model.CalendarSource;
+import com.calendarfx.model.Entry;
+import com.calendarfx.view.YearMonthView;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.ReadOnlyAppointmentList;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import java.util.logging.Logger;
+
+// class to display calendar using CalendarFX
+public class CalendarCard extends UiPart<Region> {
+
+    private static final String FXML = "CalendarCard.fxml";
+    private final Logger logger = LogsCenter.getLogger(CalendarCard.class);
+    private static final CalendarSource source = new CalendarSource("Schedule");
+    private static Calendar calendar = new Calendar("Task");
+    @FXML
+    private static YearMonthView calendarView = new YearMonthView();
+
+    public CalendarCard() {
+        super(FXML);
+        calendarView.setRequestedTime(LocalTime.now());
+        calendarView.setToday(LocalDate.now());
+        source.getCalendars().add(calendar);
+        calendarView.getCalendarSources().add(source);
+        calendarView.setClickBehaviour(YearMonthView.ClickBehaviour.SHOW_DETAILS);
+//        calendarView.setShowAddCalendarButton(false);
+//        calendarView.setShowPrintButton(false);
+//        calendarView.setShowPageToolBarControls(false);
+//        calendarView.setShowSearchField(false);
+//        calendarView.showDayPage();
+    }
+
+    public static void addAppointmentsToCalendar(ReadOnlyAppointmentList appointmentList) {
+        for (int i = 0; i < appointmentList.getAppointmentList().size(); i++) {
+            Entry<String> entry = new Entry<>(appointmentList.getAppointmentList().get(i).getDescription().description);
+            entry.setInterval(appointmentList.getAppointmentList().get(i).getTimeslot().startingDateTime,
+                    appointmentList.getAppointmentList().get(i).getTimeslot().endingDateTime);
+            calendar.addEntry(entry);
+        }
+    }
+
+    @Override
+    public YearMonthView getRoot() {
+        return calendarView;
+    }
+
+
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -51,6 +51,8 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane resultDisplayPlaceholder;
 
     @FXML
+    private StackPane calendarPlaceholder;
+    @FXML
     private StackPane statusbarPlaceholder;
 
     /**
@@ -119,8 +121,11 @@ public class MainWindow extends UiPart<Stage> {
         appointmentListPanel = new AppointmentListPanel(logic.getFilteredAppointmentList(), logic.getAddressBook());
         appointmentListPanelPlaceholder.getChildren().add(appointmentListPanel.getRoot());
         resultDisplay = new ResultDisplay();
-        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
+        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
+        CalendarCard.addAppointmentsToCalendar(logic.getAppointmentList());
+        CalendarCard calendarCard = new CalendarCard();
+        calendarPlaceholder.getChildren().add(calendarCard.getRoot());
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 

--- a/src/main/resources/view/CalendarCard.fxml
+++ b/src/main/resources/view/CalendarCard.fxml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.StackPane?>
+
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1">
+    <children>
+        <StackPane fx:id="calendarPane" prefHeight="200.0" prefWidth="200.0" />
+    </children>
+</VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,7 +6,6 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
@@ -54,13 +53,18 @@
               </padding>
               <StackPane fx:id="patientListPanelPlaceholder" HBox.hgrow="SOMETIMES"/>
             </VBox>
-
-            <VBox fx:id="appointmentList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-              <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
-              </padding>
-              <StackPane fx:id="appointmentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            <VBox HBox.hgrow="SOMETIMES">
+              <children>
+                  <StackPane fx:id="calendarPlaceholder" VBox.vgrow="SOMETIMES"/>
+                <VBox fx:id="appointmentList" styleClass="pane-with-border"  minWidth="340" prefWidth="340" VBox.vgrow="SOMETIMES">
+                  <padding>
+                    <Insets top="10" right="10" bottom="10" left="10" />
+                  </padding>
+                  <StackPane fx:id="appointmentListPanelPlaceholder" VBox.vgrow="SOMETIMES"/>
+                </VBox>
+              </children>
             </VBox>
+
           </children>
         </HBox>
 


### PR DESCRIPTION
## Known bugs:
- When I click on a date, it displays the entry list (either no entries or list of appointments on that day). Then if I change the month, the entry list still persists.
<img width="763" alt="image" src="https://user-images.githubusercontent.com/68142267/228259837-e2847d6e-a183-4aca-b4e0-02e8042ebafd.png">
To illustrate, I clicked on Jan 1, showing the appointments, then moved to March. The appointments are still visible.
- When multiple dates are clicked on the calendar, the displayed entry lists (of appointments on that day) seem to stack on top of each other.
<img width="770" alt="image" src="https://user-images.githubusercontent.com/68142267/228259639-86ae410f-0408-45cf-93e5-3b3c0fb013ef.png">
To illustrate, I clicked on Jan 1, then Jan 2. The Jan 1 entry is hidden behind Jan 2 but the box is still visible.
