### PR TITLE
Fix bugs from PE

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,7 +118,15 @@ Adds a patient to MediMeet.
 Format: `add_patient n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-A patient can have any number of tags (including 0)
+A patient can have any number of tags (including 0).
+</div>
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+MediMeet does not support phone numbers longer than 15 digits. Although MediMeet will still accept phone numbers longer than 15 digits, the application might display the patient list strangely.
+</div>
+
+<div markdown="span" class="alert alert-primary">:exclamation: **Warning:**
+Tags should be limited to 30 characters or less. If you want to record information longer than that, use the `remark` command instead.
 </div>
 
 Examples:
@@ -203,7 +211,7 @@ Adds a remark to a patient in MediMeet.
 Format: `remark_patient INDEX [r/REMARK]`
 
 * Remarks cannot be edited and can only be overwritten.
-* In order to remove notes from a patient, use `remark_patient INDEX` without the optional `[r\REMARK]`.
+* In order to remove notes from a patient, use `remark_patient INDEX` without the optional `[r\REMARK]`, or use `remark_patient INDEX r/`.
 
 * Example:
 * `remark_patient 1 r/Immunocompromised` Adds a note `Immunocompromised` to the patient.

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -49,6 +49,22 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if {@code s} is "0" or a representation of the integer zero.
+     * @param s The string to check.
+     * @return True if the string is a representation of the integer zero.
+     */
+    public static boolean isZero(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            return value == 0;
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    /**
      * Returns true if {@code s} represents a non-zero unsigned integer
      * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
      * Will return false for any other non-null string input

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,7 +12,7 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String COMMAND_ALIAS = "c";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Patient and appointment list have been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -25,7 +25,7 @@ public class RemarkCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_REMARK + "[REMARK]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_REMARK + "Immunocompromised.";
+            + PREFIX_REMARK + "Immunocompromised";
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,7 +33,7 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+        if (StringUtil.isZero(trimmedIndex) || !StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));

--- a/src/main/java/seedu/address/ui/CalendarCard.java
+++ b/src/main/java/seedu/address/ui/CalendarCard.java
@@ -8,8 +8,11 @@ import com.calendarfx.model.Calendar;
 import com.calendarfx.model.CalendarSource;
 import com.calendarfx.model.Entry;
 import com.calendarfx.view.YearMonthView;
+import com.calendarfx.view.popover.DatePopOver;
 
 import javafx.fxml.FXML;
+import javafx.scene.input.InputEvent;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.ReadOnlyAppointmentList;
@@ -18,7 +21,7 @@ import seedu.address.model.ReadOnlyAppointmentList;
  * A Calendar card that displays appointments in the appointment list.
  * Adapted from `CalendarPanel.java` written by ChoChihTun, from
  * <a href="https://github.com/CS2103JAN2018-T11-B1/main/blob/master/src/main/java/seedu/address/ui/CalendarPanel.java">
- *     Tuition Connect </a>.
+ * Tuition Connect </a>.
  */
 public class CalendarCard extends UiPart<Region> {
     private static final CalendarSource source = new CalendarSource("Schedule");
@@ -27,6 +30,7 @@ public class CalendarCard extends UiPart<Region> {
     private static YearMonthView calendarView = new YearMonthView();
     private static final String FXML = "CalendarCard.fxml";
     private final Logger logger = LogsCenter.getLogger(CalendarCard.class);
+    private DatePopOver datePopOver = null;
 
     /**
      * Creates a {@code CalendarCard}.
@@ -35,13 +39,31 @@ public class CalendarCard extends UiPart<Region> {
         super(FXML);
         calendarView.setRequestedTime(LocalTime.now());
         calendarView.setToday(LocalDate.now());
+        calendarView.setShowWeekNumbers(false);
         source.getCalendars().add(calendar);
         calendarView.getCalendarSources().add(source);
         calendarView.setClickBehaviour(YearMonthView.ClickBehaviour.SHOW_DETAILS);
+        calendarView.setDateDetailsCallback(param -> {
+            InputEvent evt = param.getInputEvent();
+            if (evt instanceof MouseEvent) {
+                MouseEvent mouseEvent = (MouseEvent) evt;
+                if (mouseEvent.getClickCount() == 1) {
+                    if (datePopOver != null) {
+                        datePopOver.hide();
+                    }
+                    datePopOver = new DatePopOver(calendarView, param.getLocalDate());
+                    datePopOver.show(param.getOwner());
+                    return true;
+                }
+            }
+
+            return false;
+        });
     }
 
     /**
      * Adds appointments to the calendar.
+     *
      * @param appointmentList The appointment list to be added to the calendar.
      */
     public static void addAppointmentsToCalendar(ReadOnlyAppointmentList appointmentList) {
@@ -51,10 +73,10 @@ public class CalendarCard extends UiPart<Region> {
         Calendar calendar = new Calendar("Task");
         for (int i = 0; i < appointmentList.getAppointmentList().size(); i++) {
             String entryTitle = appointmentList.getAppointmentList().get(i).getPatientName().fullName + ", "
-                    + appointmentList.getAppointmentList().get(i).getTimeslot().toString();
+                + appointmentList.getAppointmentList().get(i).getTimeslot().toString();
             Entry<String> entry = new Entry<>(entryTitle);
             entry.setInterval(appointmentList.getAppointmentList().get(i).getTimeslot().startingDateTime,
-                    appointmentList.getAppointmentList().get(i).getTimeslot().endingDateTime);
+                appointmentList.getAppointmentList().get(i).getTimeslot().endingDateTime);
             calendar.addEntry(entry);
         }
         source.getCalendars().add(calendar);

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2223s2-cs2103t-w12-4.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -42,6 +42,7 @@ public class UiManager implements Ui {
         try {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
+            primaryStage.setMinHeight(650);
             mainWindow.fillInnerParts();
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));


### PR DESCRIPTION
Fix the following bugs from PE:
#141: fix text shown on `clear`
#138: add limitation to tag length in UserGuide
#137: remove week numbers to make calendar view clearer
#135: add note to UserGuide that using remark with an empty command is equivalent to deleting the remark
#134: add limitation to phone number length in UserGuide
#133: make previous popup disappear upon clicking on new date
#130: fix error message in parsers
#129: set minimum height for the application
#128: fix `help` command text